### PR TITLE
fix empty fraction when setting per: "/" but not using per

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -270,7 +270,11 @@
     if normal-list.at(0).at("cond") {
       formatted += space
     }
-    formatted += " ("
+
+    if per-list.len() > 0 {
+      formatted += " ("
+    }
+    
     for (i, chunk) in normal-list.enumerate() {
       let (string: n, cond: space-set) = chunk
       if i != 0 and space-set {
@@ -278,6 +282,11 @@
       }
       formatted += n
     }
+
+    if per-list.len() == 0 {
+      return formatted
+    }
+
     formatted += ")/("
     for (i, chunk) in per-list.enumerate() {
       let (string: p, cond: space-set) = chunk
@@ -416,7 +425,11 @@
     if normal-list.at(0).at("cond") {
       formatted += space
     }
+
+    if per-list.len() > 0 {
       formatted += " ("
+    }
+
     for (i, chunk) in normal-list.enumerate() {
       let (string: n, cond: space-set) = chunk
       if i != 0 and space-set {
@@ -424,6 +437,11 @@
       }
       formatted += n
     }
+
+    if per-list.len() == 0 {
+      return formatted
+    }
+
     formatted += ")/("
     for (i, chunk) in per-list.enumerate() {
       let (string: p, cond: space-set) = chunk


### PR DESCRIPTION
Hello,

as I'm always using the fraction per-mode, I was able to set it by default using
```rust
#import "@preview/unify:0.4.1"
#let qty = unify.qty.with(per: "/")
```

However, this was giving me empty fractions when there was no unit in the denominator:
![grafik](https://github.com/ChHecker/unify/assets/23227405/e6d6a5d3-bdc7-42ec-bf16-c8c47f29e4dd)

(Of course, this also applies to calls to qty where `per: "/"` was specified directly inside the call)

This commit would fix this issue:
![grafik](https://github.com/ChHecker/unify/assets/23227405/9f88b46d-aa57-4944-88f3-241cbb4e46e9)
