### PR TITLE
Add imperial and custom units

### DIFF
--- a/imperialunits.csv
+++ b/imperialunits.csv
@@ -1,0 +1,34 @@
+twip,twip,upright("twip"),true
+thou,th,upright("th"),true
+barleycorn,barleycorn,upright("barleycorn"),true
+inch,in,upright("in"),true
+hand,hh,upright("hh"),true
+foot,ft,upright("ft"),true
+yard,yd,upright("yd"),true
+chain,ch,upright("ch"),true
+furlong,fur,upright("fur"),true
+mile,mi,upright("mi"),true
+league,lea,upright("lea"),true
+fathom,ftm,upright("ftm"),true
+cable,cable,upright("cable"),true
+nauticalmile,nmi,upright("nmi"),true
+squaremile,sqmi,upright("sq mi"),true
+fluidounce,floz,upright("fl oz"),true
+gill,gi,upright("gi"),true
+pint,pt,upright("pt"),true
+quart,qt,upright("qt"),true
+gallon,gal,upright("gal"),true
+minim,minim,upright("♏︎"),true
+fluidscruple,fls,upright("fl ℈"),true
+fluiddrachm,fldr,upright("fl ʒ"),true
+fluidounce,floz,upright("fl ℥"),true
+grain,gr,upright("gr"),true
+drachm,dr,upright("dr"),true
+ounce,oz,upright("oz"),true
+pound,lb,upright("lb"),true
+stone,st,upright("st"),true
+quarter,qtr,upright("qtr"),true
+hundredweight,cwt,upright("cwt"),true
+ton,t,upright("t"),true
+slug,slug,upright("slug"),true
+fahrenheit,dF,degree.f,false

--- a/lib.typ
+++ b/lib.typ
@@ -180,7 +180,8 @@
 }
 
 #let (prefixes, prefixes-short) = _prefix-csv("prefixes.csv")
-#let (units, units-short, units-space, units-short-space) = _unit-csv("units.csv")
+#let (siunits, siunits-short, siunits-space, siunits-short-space) = _unit-csv("units.csv")
+#let (iunits, iunits-short, iunits-space, iunits-short-space) = _unit-csv("imperialunits.csv")
 #let postfixes = _postfix-csv("postfixes.csv")
 
 #let unicode_exponent_list = for (unicode, ascii) in unicode_exponents {(unicode,)}
@@ -202,7 +203,7 @@
 
 #let chunk(string, cond) = (string: string, cond: cond)
 
-#let _format-unit-short(string, space: "#h(0.166667em)", per: "symbol") = {
+#let _format-unit-short(string, space: "#h(0.166667em)", per: "symbol", units, units-short, units-space, units-short-space) = {
   /// Format a unit using the shorthand notation.
   /// - `string`: String containing the unit.
   /// - `space`: Space between units.
@@ -340,7 +341,7 @@
   formatted
 }
 
-#let _format-unit(string, space: "#h(0.166667em)", per: "symbol") = {
+#let _format-unit(string, space: "#h(0.166667em)", per: "symbol", units, units-short, units-space, units-short-space) = {
   /// Format a unit using written-out words.
   /// - `string`: String containing the unit.
   /// - `space`: Space between units.
@@ -456,7 +457,7 @@
       unit.at("cond") = units-space.at(u)
       post = true
     } else if u != "" {
-      return _format-unit-short(string, space: space, per: per)
+      return _format-unit-short(string, space: space, per: per, units, units-short, units-space, units-short-space)
     }
   }
 
@@ -495,14 +496,22 @@
   formatted
 }
 
-#let unit(unit, space: "#h(0.166667em)", per: "symbol") = {
+#let unit(unit, space: "#h(0.166667em)", per: "symbol", units: "SI") = {
   /// Format a unit.
   /// - `unit`: String containing the unit.
   /// - `space`: Space between units.
   /// - `per`: Whether to format the units after `per` or `/` with a fraction or exponent.
 
   let formatted-unit = ""
-  formatted-unit = _format-unit(unit, space: space, per: per)
+  
+  if (units == "SI") {
+    formatted-unit = _format-unit(unit, space: space, per: per, siunits, siunits-short, siunits-space, siunits-short-space)
+  } else if (units == "Imperial") {
+    formatted-unit = _format-unit(unit, space: space, per: per, iunits, iunits-short, iunits-space, iunits-short-space)
+  } else {
+    let (units, units-short, units-space, units-short-space) = _unit-csv(units)
+    formatted-unit = _format-unit(unit, space: space, per: per, units, units-short, units-space, units-short-space)
+  }
 
   let formatted = "$" + formatted-unit + "$"
   eval(formatted)
@@ -510,7 +519,7 @@
 
 #let qty(
   value, unit, rawunit: false, space: "#h(0.166667em)",
-  multiplier: "dot", thousandsep: "#h(0.166667em)", per: "symbol") = {
+  multiplier: "dot", thousandsep: "#h(0.166667em)", per: "symbol", units: "SI") = {
   /// Format a quantity (i.e. number with a unit).
   /// - `value`: String containing the number.
   /// - `unit`: String containing the unit.
@@ -548,7 +557,14 @@
   if rawunit {
     formatted-unit = space + unit
   } else {
-    formatted-unit = _format-unit(unit, space: space, per: per)
+    if (units == "SI") {
+      formatted-unit = _format-unit(unit, space: space, per: per, siunits, siunits-short, siunits-space, siunits-short-space)
+   } else if (units == "Imperial") {
+      formatted-unit = _format-unit(unit, space: space, per: per, iunits, iunits-short, iunits-space, iunits-short-space)
+    } else {
+      let (units, units-short, units-space, units-short-space) = _unit-csv(units)
+      formatted-unit = _format-unit(unit, space: space, per: per, units, units-short, units-space, units-short-space)
+  }
   }
 
   let formatted = "$" + formatted-value + formatted-unit + "$"
@@ -669,7 +685,14 @@
   if rawunit {
     formatted-unit = space + unit
   } else {
-    formatted-unit = _format-unit(unit, space: unitspace, per: per)
+    if (units == "SI") {
+      formatted-unit = _format-unit(unit, space: space, per: per, siunits, siunits-short, siunits-space, siunits-short-space)
+  } else if (units == "Imperial") {
+      formatted-unit = _format-unit(unit, space: space, per: per, iunits, iunits-short, iunits-space, iunits-short-space)
+  } else {
+      let (units, units-short, units-space, units-short-space) = _unit-csv(units)
+      formatted-unit = _format-unit(unit, space: space, per: per, units, units-short, units-space, units-short-space)
+  }
   }
 
   let formatted = "$" + formatted-value + formatted-unit + "$"


### PR DESCRIPTION
This PR has two parts: a .csv file containing common imperial measurements for length, weight, and volume; and changes to the `unit` and `qty` functions to accommodate switching between units.

SI and imperial units are automatically loaded from their appropriate .csv files. The `unit` and `qty` functions now have an optional `units` parameter. The `units` parameter takes a string equal to either `"SI"`, `"Imperial"`, or the name of a local .csv file containing custom units.

Since the default `units` parameter is `"SI"`, this should *not* affect any existing code.

Possible problems with this implementation:

* Any custom .csv files are loaded per function invocation. This means that for projects with dozens of calls to custom units, performance might significantly degrade
* Custom .csv loading only works from the local `unify` repository, *not* the directory the main `.typ` file is in. While this solution means that users no longer have to manually edit the `lib.typ` file, I need to do more research to find out how to load files from the working directory.