### PR TITLE
Fix temperature space (#21)

### DIFF
--- a/units-en.csv
+++ b/units-en.csv
@@ -36,8 +36,8 @@ henry,H,upright("H"),true
 weber,Wb,upright("Wb"),true
 farad,F,upright("F"),true
 kelvin,K,upright("K"),true
-celsius,dC,degree.c,false
-fahrenheit,dF,degree.f,false
+celsius,dC,degree.c,true
+fahrenheit,dF,degree.f,true
 candela,cd,upright("cd"),true
 lumen,lm,upright("lm"),true
 lux,lx,upright("lx"),true

--- a/units-ru.csv
+++ b/units-ru.csv
@@ -34,8 +34,8 @@ gauss,G,upright("Гс"),true
 henry,H,upright("Гн"),true
 farad,F,upright("Ф"),true
 kelvin,K,upright("K"),true
-celsius,dC,degree.c,false
-fahrenheit,dF,degree.f,false
+celsius,dC,degree.c,true
+fahrenheit,dF,degree.f,true
 candela,cd,upright("кд"),true
 lumen,lm,upright("лм"),true
 lux,lx,upright("лк"),true


### PR DESCRIPTION
According to DIN 1301, temperature units have a space before, even with the degree symbol (as mentioned in #21).