### PR TITLE
Added unit for molar concentration

### DIFF
--- a/units-en.csv
+++ b/units-en.csv
@@ -56,3 +56,4 @@ decibel,dB,upright("dB"),true
 neper,Np,upright("Np"),true
 coulomb,C,upright("C"),true
 katal,kat,upright("kat"),true
+molar,M,upright(#text(size: 0.85em)[M]),true


### PR DESCRIPTION
Added the unit of [molar concentration](https://en.wikipedia.org/wiki/Molar_concentration#Units) – "molar", "M" for short.

P.S. The symbol value should be replaced with `upright(#smallcaps[M])` once the functionality to synthesise small capitals is implemented (see [guide](https://typst.app/docs/reference/text/smallcaps/)).