### PR TITLE
added force-parentheses to qtyrange

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -191,6 +191,7 @@
   space: "",
   unitspace: "#h(0.16667em)",
   thousandsep: "#h(0.166667em)",
+  force-parentheses: true,
   per: "symbol",
 ) = {
   /// Format a range with a unit.
@@ -223,7 +224,7 @@
     delimiter: delimiter,
     space: space,
     thousandsep: thousandsep,
-    force-parentheses: true,
+    force-parentheses: force-parentheses,
   )
 
   context {

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unify"
-version = "0.7.1"
+version = "0.7.2"
 entrypoint = "lib.typ"
 authors = ["Christopher Hecker"]
 repository = "https://github.com/ChHecker/unify"


### PR DESCRIPTION
I added the option `force-parantheses` to qtyrange.
This is then used on the _format-range call