### PR TITLE
Add `add-postfix` for user-defined postfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Units in words have four possible parts:
 - `per` forms the inverse of the following unit.
 - A written-out prefix in the sense of SI (e.g. `centi`). This is added before the unit.
 - The unit itself written out (e.g. `gram`).
-- A postfix like `squared`. This is added after the unit and takes `per` into account.
+- A postfix like `squared`. This is added after the unit and takes `per` into account. Postfixes registered with `add-postfix` are instead appended to the unit symbol verbatim (see below).
 
 The shorthand notation also has four parts:
 - `/` forms the inverse of the following unit.
@@ -48,11 +48,13 @@ The shorthand notation also has four parts:
 
 Note: Use `u` for micro.
 
-The possible values of the three latter parts are loaded at runtime from `prefixes.csv`, `units.csv`, and `postfixes.csv` (in the library directory). Your own units etc. can be permanently added in these files. At runtime, they can be added using `add-unit` and `add-prefix`, respectively. The formats for the pre- and postfixes are:
+The possible values of the three latter parts are loaded at runtime from `prefixes.csv`, `units.csv`, and `postfixes.csv` (in the library directory). Your own units etc. can be permanently added in these files. At runtime, they can be added using `add-unit`, `add-prefix`, and `add-postfix`, respectively. The formats for the pre- and postfixes are:
 
 | pre-/postfix | shorthand | symbol       |
 | ------------ | --------- | ------------ |
 | milli        | m         | upright("m") |
+
+Note that the built-in postfixes in `postfixes.csv` (e.g. `squared`) are a special case: their symbol is a numeric exponent that is rendered as such and honours `per`. Postfixes added with `add-postfix` append their `symbol` to the unit symbol verbatim, e.g. `#add-postfix("gf12", "gf12", "_(upright(\"GF12\"))")` renders `qty(1, "gate-equivalent gf12")` with a `GF12` subscript.
 
 and for units:
 

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -13,6 +13,10 @@ Adding your own prefix and unit:
 #add-unit("unit", "U", "bold(\"unit\")")
 $ unit("PU") $
 
+Adding your own postfix (appended to the unit symbol):
+#add-postfix("post", "po", "_(upright(\"post\"))")
+$ qty(1, "meter post") $
+
 #set text(lang: "ru")
 Работа пакета с русскими символами:
 $ num("-1.32865+-0.50273e-6") $

--- a/format.typ
+++ b/format.typ
@@ -337,6 +337,8 @@
 
   let (prefixes, prefixes-short) = _prefixes()
 
+  let (postfixes, postfixes-short) = _postfixes-db()
+
   let formatted = ""
 
   // needed for fraction formatting
@@ -356,9 +358,14 @@
   for u in split {
     // expecting postfix
     if post {
-      let is_postfix = u in _postfixes
-      if is_postfix {
+      // Built-in numeric postfixes (e.g. `squared`) render as exponents,
+      // user-defined ones (see `add-postfix`) are appended to the symbol.
+      let is_exponent = u in _postfixes
+      let is_postfix = u in postfixes
+      if is_exponent {
         unit.at("exponent") = _postfixes.at(u)
+      } else if is_postfix {
+        unit.at("symbol") += postfixes.at(u)
       }
 
       if per-set {
@@ -372,7 +379,7 @@
 
       unit = _unit("", none, false)
 
-      if is_postfix {
+      if is_exponent or is_postfix {
         continue
       }
     }

--- a/init.typ
+++ b/init.typ
@@ -54,6 +54,10 @@
   (units, units-short, units-space, units-short-space)
 }
 
+// Built-in numeric postfixes (e.g. `squared` -> `2`). These render as
+// exponents and honour `per`. User-defined postfixes added via `add-postfix`
+// are kept separately in the language database (see `_postfixes-db`) and are
+// appended to the unit symbol verbatim.
 #let _postfixes = _postfix-csv("postfixes.csv")
 
 #let _add-money-units(data) = {
@@ -81,10 +85,12 @@
     "en": (
       "units": (_add-money-units(_unit-csv("units-en.csv"))),
       "prefixes": (_prefix-csv("prefixes-en.csv")),
+      "postfixes": ((:), (:)),
     ),
     "ru": (
       "units": (_add-money-units(_unit-csv("units-ru.csv"))),
       "prefixes": (_prefix-csv("prefixes-ru.csv")),
+      "postfixes": ((:), (:)),
     ),
   ),
 )
@@ -119,5 +125,16 @@
     data.at(lang).units
   } else {
     data.en.units
+  }
+}
+
+// get postfixes
+#let _postfixes-db() = {
+  let lang = text.lang
+  let data = _lang-db.get()
+  if lang in data {
+    data.at(lang).postfixes
+  } else {
+    data.en.postfixes
   }
 }

--- a/lib.typ
+++ b/lib.typ
@@ -71,6 +71,21 @@
   }
 }
 
+#let add-postfix(postfix, shorthand, symbol) = {
+  /// Add a new postfix.
+  /// - `postfix`: Full name of the postfix.
+  /// - `shorthand`: Shorthand of the postfix, usually only 1-2 letters.
+  /// - `symbol`: String that will be appended to the unit symbol.
+  context {
+    let lang = _get-language()
+
+    _lang-db.update(db => {
+      db.at(lang).at("postfixes").at(0).insert(postfix, symbol)
+      db.at(lang).at("postfixes").at(1).insert(shorthand, symbol)
+      db
+    })
+  }
+}
 
 #let unit(unit, space: "#h(0.166667em)", per: "symbol") = {
   /// Format a unit.


### PR DESCRIPTION
## Summary

`add-unit` and `add-prefix` let users register units and prefixes at runtime, but there is no equivalent for postfixes — even though the README already documents postfixes as sharing the `(name, shorthand, symbol)` format of prefixes.

This PR adds `add-postfix(postfix, shorthand, symbol)`, mirroring `add-prefix`:

- User-defined postfixes are stored per-language in the language database (`_lang-db`) and **appended verbatim** to the unit symbol, so the caller controls the formatting via the `symbol` string (e.g. a subscript with `_(...)`).
- The built-in numeric postfixes from `postfixes.csv` (e.g. `squared`, `cubed`) are **unchanged**: they still render as exponents and honour `per`. In `_format-unit`, a trailing token is checked against those first, then against user postfixes.

## Motivation

I needed to annotate a unit with a technology-node subscript in a document, e.g. gate-equivalents specific to a process node:

```typ
#add-unit("ge", "ge", "upright(\"GE\")")
#add-postfix("gf12", "gf12", "_(upright(\"GF12\"))")
$ qty(1, "ge gf12") = qty(0.121, "micro meter squared") $   // renders GE with a GF12 subscript
```

## Changes

- `lib.typ`: add `add-postfix`.
- `init.typ`: add a `postfixes` category to `_lang-db` (empty per language) and a `_postfixes-db()` accessor; clarify the comment on the built-in `_postfixes`.
- `format.typ`: look up user postfixes in `_format-unit` and append their symbol.
- `README.md` / `examples/example.typ`: document and demonstrate `add-postfix`.

## Compatibility

Backward compatible — existing `squared`/`cubed` postfixes and the `per`-aware behaviour are preserved (verified: `meter per second squared` still renders `m s⁻²`).